### PR TITLE
[consul-integration] Update Consul integration

### DIFF
--- a/consul/README.md
+++ b/consul/README.md
@@ -36,7 +36,9 @@ The Consul plugin can be customized via environment variables.
 
 |Variable        |Default              |Description                                                                  |
 |----------------|---------------------|-----------------------------------------------------------------------------|
-|url             |http://localhost:8500|The base URL and port for Consul HTTP API.                                   |
+|protocol        |http                 |Consul REST API protocol. Use `https` when TLS is enabled.                   |
+|host            |localhost            |Consul host.                                                                 |
+|port            |8500                 |Consul REST API port.                                                        |
 |client_cert_file|                     |Path to a client cert file to use for TLS when `verify_incoming` is enabled. |
 |private_key_file|                     |Path to a client key file to use for TLS when `verify_incoming` is enabled.  |
 |ca_bundle_file  |                     |Path to the CA file to use for TLS when communicating with Consul.           |

--- a/consul/README.md
+++ b/consul/README.md
@@ -1,0 +1,49 @@
+Consul Integration
+==================
+
+== Description ==
+
+Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.
+
+This integration will monitor your Consul cluster by collecting metrics from its RESTful HTTP API and the agent `/metrics` endpoint.
+
+Once enabled you will get a default Consul dashboard and alert rules template to help you get started monitoring your key Consul metrics.
+
+== Metrics Collected ==
+
+| Metric Name                   |Type |Labels                                   |Unit |Description                                                                     |
+|-------------------------------|-----|-----------------------------------------|-----|--------------------------------------------------------------------------------|
+|consul_catalog_services        |Gauge|                                         |     |Total number of services.                                                       |
+|consul_client_agents           |Gauge|                                         |     |Total number of agents running in client mode.                                  |
+|consul_datacenters             |Gauge|                                         |     |Total number of datacenters.                                                    |
+|consul_health_failure_tolerance|Gauge|                                         |     |Number of voting servers that the cluster can lose while continuing to function.|
+|consul_health_node_status      |Gauge|check,node,status                        |     |Node checks status.                                                             |
+|consul_health_service_status   |Gauge|check,node,status,service_id,service_name|     |Service checks status.                                                          |
+|consul_raft_leader             |Gauge|                                         |     |Indicates whether the cluster has a raft leader.                                |
+|consul_raft_peers              |Gauge|                                         |     |Total number of agents running in server mode.                                  |
+|consul_runtime_alloc_bytes     |Gauge|                                         |bytes|Number of bytes allocated by the Consul process.                                |
+|consul_runtime_heap_objects    |Gauge|                                         |     |Number of objects allocated on the heap.                                        |
+|consul_runtime_num_goroutines  |Gauge|                                         |     |Rumber of running goroutines.                                                   |
+|consul_serf_lan_members        |Gauge|                                         |     |Total number of members in the cluster.                                         |
+
+== Installation ==
+
+Run the Consul plugin against your Consul instances and it will start collecting the metrics. If your cluster is secured with RPC encryption using TLS or ACL tokens, you must provide additional plugin configurations via environment variables.
+
+### Plugin Environment Variables
+
+The Consul plugin can be customized via environment variables.
+
+|Variable        |Default              |Description                                                                  |
+|----------------|---------------------|-----------------------------------------------------------------------------|
+|url             |http://localhost:8500|The base URL and port for Consul HTTP API.                                   |
+|client_cert_file|                     |Path to a client cert file to use for TLS when `verify_incoming` is enabled. |
+|private_key_file|                     |Path to a client key file to use for TLS when `verify_incoming` is enabled.  |
+|ca_bundle_file  |                     |Path to the CA file to use for TLS when communicating with Consul.           |
+|acl_token       |                     |The token ID used in each RPC request to the servers when ACL system is used.|
+
+== Changelog ==
+
+|Version|Release Date|Description                                         |
+|-------|------------|----------------------------------------------------|
+|1.0    |31-May-2018 |Initial version of our Consul monitoring integration|

--- a/consul/alerts/consul.yaml
+++ b/consul/alerts/consul.yaml
@@ -1,0 +1,31 @@
+actions: {}
+criteria:
+  metricCriteria:
+  - description: Consul Raft cluster has no leader.
+    disabled: false
+    lastTriggered: ""
+    levelThresholds:
+    - level: warning
+      operator: <
+      threshold: 1
+    - level: critical
+      operator: <
+      threshold: 1
+    query: name,consul_raft_leader,:eq,:min,(,host,),:by
+    timeout: 60
+    title: Raft Leader Down
+  serviceCriteria:
+  - description: Consul nodes are unavailable.
+    disabled: false
+    lastTriggered: ""
+    service: consul
+    statusThreshold:
+      critical: 2
+      ok: 2
+      warning: 2
+    title: Consul Unavailable
+description: Standard Consul Alerts
+labels: []
+muted: false
+name: consul
+title: Consul

--- a/consul/dashboards/consul.yaml
+++ b/consul/dashboards/consul.yaml
@@ -1,9 +1,9 @@
-description: ""
+description: Consul cluster overview
 icon:
-  color: '#000000'
+  color: '#c3348b'
   name: dashboard
 labels: []
-name: Consul
+name: consul
 scopes: []
 theme: light
 title: Consul
@@ -127,7 +127,7 @@ widgets:
         linkType: dashboard
         path: ""
       queries:
-      - query: name,consul.runtime.num_goroutines,:eq,:max,(,host,),:by
+      - query: name,consul_runtime_num_goroutines,:eq,:max,(,host,),:by
         visible: true
       seriesStyle:
         color: '#588fd8'
@@ -160,7 +160,7 @@ widgets:
         linkType: dashboard
         path: ""
       queries:
-      - query: name,consul.runtime.alloc_bytes,:eq,:max,(,host,),:by
+      - query: name,consul_runtime_alloc_bytes,:eq,:max,(,host,),:by
         visible: true
       seriesStyle:
         color: '#588fd8'
@@ -193,7 +193,7 @@ widgets:
         linkType: dashboard
         path: ""
       queries:
-      - query: name,consul.runtime.heap_objects,:eq,:max,(,host,),:by
+      - query: name,consul_runtime_heap_objects,:eq,:max,(,host,),:by
         visible: true
       seriesStyle:
         color: '#588fd8'

--- a/consul/dashboards/consul.yaml
+++ b/consul/dashboards/consul.yaml
@@ -1,223 +1,250 @@
 description: ""
 icon:
-  color: '#ca557b'
-  name: data_usage
+  color: '#000000'
+  name: dashboard
 labels: []
-name: consul
+name: Consul
 scopes: []
 theme: light
 title: Consul
 widgets:
-  chartwidgets:
-  - col: 10
+  chartWidgets:
+  - col: 4
     height: 2
     options:
       axes:
-        xaxis:
+        xAxis:
           mode: Time
-          showgridlines: false
-        yaxis:
-          max: null
+          showGridLines: false
+        yAxis:
           min: 0
-          showgridlines: false
+          showGridLines: false
           title: ""
           unit: ""
-          unitposition: After
-      charttype: Line
+          unitPosition: After
+      chartType: Line
       description: ""
-      externallink:
-        linktype: dashboard
+      externalLink:
+        linkType: dashboard
         path: ""
       queries:
       - query: name,service.status,:eq,service,consul,:eq,:and,:avg,(,host,),:by
         visible: true
-      seriesstyle:
+      seriesStyle:
         color: '#588fd8'
         palette: MultiColor
       summarization: Avg
       thresholds:
-      - display: Line
-        linestyle: Solid
+      - display: None
+        lineStyle: Solid
         status: Error
-        threshold: 1
+        threshold: 0
       title: Unhealthy Consul Servers
-    row: 0
-    width: 3
-  - col: 10
+    row: 4
+    width: 12
+  - col: 3
     height: 2
     options:
       axes:
-        xaxis:
+        xAxis:
           mode: Time
-          showgridlines: true
-        yaxis:
-          max: null
+          showGridLines: false
+        yAxis:
           min: 0
-          showgridlines: false
+          showGridLines: false
           title: ""
           unit: ""
-          unitposition: After
-      charttype: Line
+          unitPosition: After
+      chartType: Line
       description: ""
-      externallink:
-        linktype: dashboard
+      externalLink:
+        linkType: dashboard
         path: ""
       queries:
-      - query: name,consul_members,:eq,role,consul,:eq,:and,:avg,(,host,),:by
+      - query: name,consul_health_node_status,:eq,:max,(,host,status,),:by
         visible: true
-      seriesstyle:
+      seriesStyle:
         color: '#588fd8'
         palette: MultiColor
       summarization: Avg
       thresholds:
       - display: None
-        linestyle: Solid
+        lineStyle: Solid
         status: Error
         threshold: 0
-      title: Consul Members
-    row: 4
-    width: 3
-  - col: 10
+      title: Node Check Status
+    row: 7
+    width: 5
+  - col: 11
     height: 2
     options:
       axes:
-        xaxis:
+        xAxis:
           mode: Time
-          showgridlines: true
-        yaxis:
-          max: null
+          showGridLines: false
+        yAxis:
           min: 0
-          showgridlines: false
+          showGridLines: false
           title: ""
           unit: ""
-          unitposition: After
-      charttype: Line
+          unitPosition: After
+      chartType: Line
       description: ""
-      externallink:
-        linktype: dashboard
+      externalLink:
+        linkType: dashboard
         path: ""
       queries:
-      - query: name,consul_services,:eq,role,consul,:eq,:and,:avg,(,host,),:by
+      - query: name,consul_health_service_status,:eq,:max,(,host,status,),:by
         visible: true
-      seriesstyle:
+      seriesStyle:
         color: '#588fd8'
         palette: MultiColor
       summarization: Avg
       thresholds:
       - display: None
-        linestyle: Solid
+        lineStyle: Solid
         status: Error
         threshold: 0
-      title: Consul Services
-    row: 2
-    width: 3
-  imagewidgets: []
-  markdownwidgets:
+      title: Service Check Status
+    row: 7
+    width: 5
+  - col: 10
+    height: 2
+    options:
+      axes:
+        xAxis:
+          mode: Time
+          showGridLines: false
+        yAxis:
+          min: 0
+          showGridLines: false
+          title: ""
+          unit: ""
+          unitPosition: After
+      chartType: StackedArea
+      description: ""
+      externalLink:
+        linkType: dashboard
+        path: ""
+      queries:
+      - query: name,consul.runtime.num_goroutines,:eq,:max,(,host,),:by
+        visible: true
+      seriesStyle:
+        color: '#588fd8'
+        palette: MultiColor
+      summarization: Avg
+      thresholds:
+      - display: None
+        lineStyle: Solid
+        status: Error
+        threshold: 0
+      title: GoRoutines Total
+    row: 10
+    width: 6
   - col: 0
     height: 2
     options:
-      content: |
-        <h1>Service Checks</h1>
-      markdown: '# Service Checks'
-    row: 2
-    width: 2
+      axes:
+        xAxis:
+          mode: Time
+          showGridLines: false
+        yAxis:
+          min: 0
+          showGridLines: false
+          title: ""
+          unit: ""
+          unitPosition: After
+      chartType: Bar
+      description: ""
+      externalLink:
+        linkType: dashboard
+        path: ""
+      queries:
+      - query: name,consul.runtime.alloc_bytes,:eq,:max,(,host,),:by
+        visible: true
+      seriesStyle:
+        color: '#588fd8'
+        palette: MultiColor
+      summarization: Avg
+      thresholds:
+      - display: None
+        lineStyle: Solid
+        status: Error
+        threshold: 0
+      title: 'Consul Process: Bytes Alloc'
+    row: 10
+    width: 5
+  - col: 5
+    height: 2
+    options:
+      axes:
+        xAxis:
+          mode: Time
+          showGridLines: false
+        yAxis:
+          min: 0
+          showGridLines: false
+          title: ""
+          unit: ""
+          unitPosition: After
+      chartType: Line
+      description: ""
+      externalLink:
+        linkType: dashboard
+        path: ""
+      queries:
+      - query: name,consul.runtime.heap_objects,:eq,:max,(,host,),:by
+        visible: true
+      seriesStyle:
+        color: '#588fd8'
+        palette: MultiColor
+      summarization: Avg
+      thresholds:
+      - display: None
+        lineStyle: Solid
+        status: Error
+        threshold: 0
+      title: Heap Objects
+    row: 10
+    width: 5
+  markdownWidgets:
   - col: 0
-    height: 2
+    height: 6
     options:
       content: |
-        <h1>Node Checks</h1>
-      markdown: '# Node Checks'
-    row: 4
-    width: 2
-  numberwidgets:
-  - col: 2
-    height: 2
-    options:
-      color: '#ca557b'
-      description: Shows minimum no. of leaders across all Consul nodes, should be
-        1 but if less means at least one node is disconnected from the leader
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
-        path: ""
-      icon: data_usage
-      query:
-        query: name,consul_raft_leader,:eq,:min
-        visible: true
-      rounding: None
-      statistic: LastValue
-      thresholds:
-      - status: Error
-        threshold: 0
-      title: Total Leaders
-      unit: ""
-      unitposition: After
+        <p><img src="https://www.datocms-assets.com/2885/1506456506-blog-consul-list.svg" alt="Consul logo"/></p>
+      markdown: '![Consul logo](https://www.datocms-assets.com/2885/1506456506-blog-consul-list.svg)'
     row: 0
-    width: 2
-  - col: 4
+    width: 4
+  - col: 0
+    height: 1
+    options:
+      content: |
+        <h1>Checks</h1>
+      markdown: '# Checks'
+    row: 6
+    width: 16
+  - col: 0
+    height: 1
+    options:
+      content: |
+        <h1>Runtime</h1>
+      markdown: '# Runtime'
+    row: 9
+    width: 16
+  numberWidgets:
+  - col: 7
     height: 2
     options:
-      color: '#ca557b'
-      description: Shows number of Consul peer agents in Raft Cluster
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
+      color: '#588fd8'
+      description: ""
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
         path: ""
-      icon: data_usage
-      query:
-        query: name,consul_raft_peers,:eq,:max
-        visible: true
-      rounding: None
-      statistic: LastValue
-      thresholds:
-      - status: Error
-        threshold: 0
-      title: Total Peers
-      unit: ""
-      unitposition: After
-    row: 0
-    width: 2
-  - col: 8
-    height: 2
-    options:
-      color: '#ca557b'
-      description: Shows number of Consul Nodes
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
-        path: ""
-      icon: data_usage
-      query:
-        query: name,consul_services,:eq,:max
-        visible: true
-      rounding: None
-      statistic: LastValue
-      thresholds:
-      - status: Error
-        threshold: 0
-      title: Total Services
-      unit: ""
-      unitposition: After
-    row: 0
-    width: 2
-  - col: 6
-    height: 2
-    options:
-      color: '#ca557b'
-      description: Shows number of Consul Nodes
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
-        path: ""
-      icon: data_usage
+      icon: check
       query:
         query: name,consul_serf_lan_members,:eq,:max
         visible: true
@@ -226,225 +253,224 @@ widgets:
       thresholds:
       - status: Error
         threshold: 0
-      title: Total Members
+      title: Consul Members
       unit: ""
-      unitposition: After
+      unitPosition: After
     row: 0
-    width: 2
-  - col: 2
+    width: 3
+  - col: 13
     height: 2
     options:
-      color: '#ca557b'
+      color: '#588fd8'
       description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
         path: ""
-      icon: data_usage
+      icon: check
       query:
-        query: name,consul_health_service_status,:eq,status,passing,:eq,:and,:sum,:cf-max
+        query: name,consul_raft_peers,:eq,:max
         visible: true
       rounding: None
       statistic: LastValue
       thresholds:
       - status: Error
         threshold: 0
-      title: SC - Passing
+      title: Consul Server Agents
       unit: ""
-      unitposition: After
+      unitPosition: After
+    row: 0
+    width: 3
+  - col: 10
+    height: 2
+    options:
+      color: '#588fd8'
+      description: ""
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
+        path: ""
+      icon: check
+      query:
+        query: name,consul_client_agents,:eq,:max
+        visible: true
+      rounding: None
+      statistic: LastValue
+      thresholds:
+      - status: Error
+        threshold: 0
+      title: Consul Client Agents
+      unit: ""
+      unitPosition: After
+    row: 0
+    width: 3
+  - col: 7
+    height: 2
+    options:
+      color: '#588fd8'
+      description: ""
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
+        path: ""
+      icon: check
+      query:
+        query: name,consul_datacenters,:eq,:max
+        visible: true
+      rounding: None
+      statistic: LastValue
+      thresholds:
+      - status: Error
+        threshold: 0
+      title: Datacenters
+      unit: ""
+      unitPosition: After
     row: 2
-    width: 2
+    width: 3
   - col: 4
     height: 2
     options:
-      color: '#ca557b'
+      color: '#588fd8'
       description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
         path: ""
-      icon: data_usage
+      icon: check
       query:
-        query: name,consul_health_service_status,:eq,status,warning,:eq,:and,:sum,:cf-max
+        query: name,consul_raft_leader,:eq,:min
         visible: true
       rounding: None
       statistic: LastValue
       thresholds:
       - status: Error
         threshold: 0
-      title: SC - Warning
+      title: Raft Leaders
       unit: ""
-      unitposition: After
+      unitPosition: After
     row: 2
-    width: 2
-  - col: 6
+    width: 3
+  - col: 10
     height: 2
     options:
-      color: '#ca557b'
+      color: '#588fd8'
       description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
         path: ""
-      icon: data_usage
+      icon: check
       query:
-        query: name,consul_health_service_status,:eq,status,critical,:eq,:and,:sum,:cf-max
+        query: name,consul_catalog_services,:eq,:max
         visible: true
       rounding: None
       statistic: LastValue
       thresholds:
       - status: Error
         threshold: 0
-      title: SC - Critical
+      title: Services
       unit: ""
-      unitposition: After
+      unitPosition: After
     row: 2
-    width: 2
-  - col: 8
+    width: 3
+  - col: 13
     height: 2
     options:
-      color: '#ca557b'
+      color: '#588fd8'
       description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
         path: ""
-      icon: data_usage
+      icon: check
       query:
-        query: name,consul_health_service_status,:eq,status,maintenance,:eq,:and,:sum,:cf-max
+        query: name,consul_health_failure_tolerance,:eq,:max
         visible: true
       rounding: None
       statistic: LastValue
       thresholds:
-      - status: Error
+      - status: Warning
         threshold: 0
-      title: SC - Maintenance
+      title: Raft Failure Tolerance
       unit: ""
-      unitposition: After
+      unitPosition: After
     row: 2
-    width: 2
-  - col: 2
-    height: 2
-    options:
-      color: '#ca557b'
-      description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
-        path: ""
-      icon: data_usage
-      query:
-        query: name,consul_health_node_status,:eq,status,passing,:eq,:and,:sum,:cf-max
-        visible: true
-      rounding: None
-      statistic: LastValue
-      thresholds:
-      - status: Error
-        threshold: 0
-      title: NC - Passing
-      unit: ""
-      unitposition: After
-    row: 4
-    width: 2
-  - col: 4
-    height: 2
-    options:
-      color: '#ca557b'
-      description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
-        path: ""
-      icon: data_usage
-      query:
-        query: name,consul_health_node_status,:eq,status,warning,:eq,:and,:sum,:cf-max
-        visible: true
-      rounding: None
-      statistic: LastValue
-      thresholds:
-      - status: Error
-        threshold: 0
-      title: NC - Warning
-      unit: ""
-      unitposition: After
-    row: 4
-    width: 2
-  - col: 6
-    height: 2
-    options:
-      color: '#ca557b'
-      description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
-        path: ""
-      icon: data_usage
-      query:
-        query: name,consul_health_node_status,:eq,status,critical,:eq,:and,:sum,:cf-max
-        visible: true
-      rounding: None
-      statistic: LastValue
-      thresholds:
-      - status: Error
-        threshold: 0
-      title: NC - Critical
-      unit: ""
-      unitposition: After
-    row: 4
-    width: 2
-  - col: 8
-    height: 2
-    options:
-      color: '#ca557b'
-      description: ""
-      displaymax: 0
-      displaymin: 0
-      displaytrend: SparkLine
-      externallink:
-        linktype: dashboard
-        path: ""
-      icon: data_usage
-      query:
-        query: name,consul_health_node_status,:eq,status,maintenance,:eq,:and,:sum,:cf-max
-        visible: true
-      rounding: None
-      statistic: LastValue
-      thresholds:
-      - status: Error
-        threshold: 0
-      title: NC - Maintenance
-      unit: ""
-      unitposition: After
-    row: 4
-    width: 2
-  statuswidgets:
+    width: 3
   - col: 0
     height: 2
-    id: 853188fd-52d3-4c2e-9159-9118f15162fc
+    options:
+      color: '#ff5e44'
+      description: ""
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
+        path: ""
+      icon: thumb_down
+      query:
+        query: name,consul_health_node_status,:eq,status,critical,:eq,:and,:sum
+        visible: true
+      rounding: None
+      statistic: LastValue
+      thresholds:
+      - status: Error
+        threshold: 1
+      title: 'Nodes Check: Critical'
+      unit: ""
+      unitPosition: After
+    row: 7
+    width: 3
+  - col: 8
+    height: 2
+    options:
+      color: '#ff5e44'
+      description: ""
+      displayMax: 0
+      displayMin: 0
+      displayTrend: SparkLine
+      externalLink:
+        linkType: dashboard
+        path: ""
+      icon: thumb_down
+      query:
+        query: name,consul_health_service_status,:eq,status,critical,:eq,:and,:sum
+        visible: true
+      rounding: None
+      statistic: LastValue
+      thresholds:
+      - status: Error
+        threshold: 1
+      title: 'Services Check: Critical'
+      unit: ""
+      unitPosition: After
+    row: 7
+    width: 3
+  statusWidgets:
+  - col: 4
+    height: 2
+    id: c8eed942-2233-4a7e-a554-407d6faa1898
     options:
       description: ""
-      externallink:
-        linktype: dashboard
+      externalLink:
+        linkType: dashboard
         path: ""
       queries:
-      - labelselectors: []
-        scoped: false
+      - scoped: false
         service: consul
-      showicon: true
-      title: Consul
+      showIcon: true
+      title: Consul Cluster Health
     row: 0
-    width: 2
+    width: 3

--- a/consul/plugins/consul.py
+++ b/consul/plugins/consul.py
@@ -134,7 +134,10 @@ class ConsulPlugin(Plugin):
         :param endpoint:    The endpoint to query, with leading /. i.e. '/v1/agent/self'
         :return:            Returns the JSON response as json if successful
         """
-        url = self.get('url', 'http://localhost:8500') + endpoint
+        protocol = self.get('protocol', 'http')
+        host = self.get('host', 'localhost')
+        port = self.get('port', 8500)
+        url = "%s://%s:%s%s" % (protocol, host, port, endpoint)
 
         try:
             clientcertfile = self.get('client_cert_file', None)

--- a/consul/plugins/consul.py
+++ b/consul/plugins/consul.py
@@ -107,9 +107,9 @@ class ConsulPlugin(Plugin):
             metrics = self.__consul_request('/v1/agent/metrics')
             for metric in metrics['Gauges']:
                 if metric['Name'] in GAUGE_METRICS:
-                    self.gauge(metric['Name'], metric['Labels']).set(metric['Value'])
+                    self.gauge(metric['Name'].replace('.', '_'), metric['Labels']).set(metric['Value'])
                 elif metric['Name'] in COUNTER_METRICS:
-                    self.counter(metric['Name'], metric['Labels']).set(metric['Count'])
+                    self.counter(metric['Name'].replace('.', '_'), metric['Labels']).set(metric['Count'])
 
             if autopilot['Healthy']:
                 return Status.OK

--- a/consul/plugins/consul.py
+++ b/consul/plugins/consul.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
- Consul check aligned with Prometheus exporter metrics: https://github.com/prometheus/consul_exporter
+ Consul check aligned with Promtheus exporter metrics: https://github.com/prometheus/consul_exporter
 """
 
 import sys, requests
@@ -103,7 +103,7 @@ class ConsulPlugin(Plugin):
                     labels['status'] = 'maintenance'
                     self.gauge("consul_health_node_status", labels).set(maintenance)
 
-
+            # Runtime metrics
             metrics = self.__consul_request('/v1/agent/metrics')
             for metric in metrics['Gauges']:
                 if metric['Name'] in GAUGE_METRICS:
@@ -114,10 +114,10 @@ class ConsulPlugin(Plugin):
             if autopilot['Healthy']:
                 return Status.OK
             else:
-                return Status.CRITICAL
-        except:
+                return Status.CRITICAL 
+        except Exception as ex:
+            self.logger.error('Unable to scrape metrics from Consul: %s', str(ex))
             return Status.CRITICAL
-
 
     def __consul_request(self, endpoint):
         """
@@ -141,7 +141,7 @@ class ConsulPlugin(Plugin):
             privatekeyfile = self.get('private_key_file', None)
             cabundlefile = self.get('ca_bundle_file', None)
             acl_token = self.get('acl_token', None)
-
+            requests.packages.urllib3.disable_warnings()
             headers = {}
             if acl_token:
                 headers['X-Consul-Token'] = acl_token
@@ -161,9 +161,7 @@ class ConsulPlugin(Plugin):
         resp.raise_for_status()
         return resp.json()
 
-
     def __get_agent_config(self):
-
         local_agent = {}
         local_agent['local_config'] = self.__consul_request('/v1/agent/self')
 

--- a/consul/plugins/consul.py
+++ b/consul/plugins/consul.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
- Consul check aligned with Promtheus exporter metrics: https://github.com/prometheus/consul_exporter
+ Consul check aligned with Prometheus exporter metrics: https://github.com/prometheus/consul_exporter
 """
 
 import sys, requests
@@ -9,13 +9,24 @@ import sys, requests
 from outlyer_plugin import Plugin, Status
 
 
+GAUGE_METRICS = [
+    'consul.runtime.num_goroutines',
+    'consul.runtime.alloc_bytes',
+    'consul.runtime.heap_objects',
+]
+
+COUNTER_METRICS = []
+
+
 class ConsulPlugin(Plugin):
 
     def collect(self, _):
-
         try:
-
             local_agent = self.__get_agent_config()
+
+            # How many members are in the cluster.
+            members = self.__consul_request('/v1/catalog/nodes')
+            self.gauge("consul_serf_lan_members", {}).set(len(members))
 
             # How many peers (servers) are in the Raft cluster.
             peers = self.__consul_request('/v1/status/peers')
@@ -24,25 +35,31 @@ class ConsulPlugin(Plugin):
             else:
                 self.gauge("consul_raft_peers", {}).set(0)
 
+            clients = len(members)-len(peers)
+            self.gauge("consul_client_agents", {}).set(clients)
+
             # Does Raft cluster have a leader (according to this node).
             if not local_agent['leader_url']:
                 self.gauge("consul_raft_leader", {}).set(0)
             else:
                 self.gauge("consul_raft_leader", {}).set(1)
 
-            # How many members are in the cluster.
-            nodes = self.__consul_request('/v1/catalog/nodes')
-            self.gauge("consul_serf_lan_members", {}).set(len(nodes))
+            # Number of datacenters
+            datacenters = self.__consul_request('/v1/catalog/datacenters')
+            self.gauge("consul_datacenters", {}).set(len(datacenters))
 
             # How many services are in the cluster.
             services = self.__consul_request('/v1/catalog/services')
             self.gauge("consul_catalog_services", {}).set(len(services))
 
+            # Failure Tolerance
+            autopilot = self.__consul_request('/v1/operator/autopilot/health')
+            self.gauge("consul_health_failure_tolerance", {}).set(autopilot['FailureTolerance'])
+
             # Make service checks from health checks for all services in catalog
             health_state = self.__consul_request('/v1/health/state/any')
             # health checks return Status: passing, warning, critical, maintenance
             for check in health_state:
-
                 passing = 0
                 warning = 0
                 critical = 0
@@ -86,25 +103,36 @@ class ConsulPlugin(Plugin):
                     labels['status'] = 'maintenance'
                     self.gauge("consul_health_node_status", labels).set(maintenance)
 
-            return Status.OK
 
+            metrics = self.__consul_request('/v1/agent/metrics')
+            for metric in metrics['Gauges']:
+                if metric['Name'] in GAUGE_METRICS:
+                    self.gauge(metric['Name'], metric['Labels']).set(metric['Value'])
+                elif metric['Name'] in COUNTER_METRICS:
+                    self.counter(metric['Name'], metric['Labels']).set(metric['Count'])
+
+            if autopilot['Healthy']:
+                return Status.OK
+            else:
+                return Status.CRITICAL
         except:
             return Status.CRITICAL
+
 
     def __consul_request(self, endpoint):
         """
         Make a request to an endpoint on Consul. Looks up the following check variables
         to override connection settings:
 
-            url: 				The URL to connect to Consul, change to https if using SSL.
+            url:                The URL to connect to Consul, change to https if using SSL.
                                 Defaults to 'http://localhost:8500'
-            client_cert_file: 	If using SSL, the public client certificate file
-            private_key_file: 	If using SSL, the private key file
-            ca_bundle_file: 	If using SSL, a CA bundle file with certificates
-            acl_token: 			Access control token to call Consul API if enabled
+            client_cert_file:   If using SSL, the public client certificate file
+            private_key_file:   If using SSL, the private key file
+            ca_bundle_file:     If using SSL, a CA bundle file with certificates
+            acl_token:          Access control token to call Consul API if enabled
 
-        :param endpoint:	The endpoint to query, with leading /. i.e. '/v1/agent/self'
-        :return: 			Returns the JSON response as json if sucessful
+        :param endpoint:    The endpoint to query, with leading /. i.e. '/v1/agent/self'
+        :return:            Returns the JSON response as json if successful
         """
         url = self.get('url', 'http://localhost:8500') + endpoint
 
@@ -132,6 +160,7 @@ class ConsulPlugin(Plugin):
 
         resp.raise_for_status()
         return resp.json()
+
 
     def __get_agent_config(self):
 

--- a/consul/plugins/consul.py
+++ b/consul/plugins/consul.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
- Consul check aligned with Promtheus exporter metrics: https://github.com/prometheus/consul_exporter
+ Consul check aligned with Prometheus exporter metrics: https://github.com/prometheus/consul_exporter
 """
 
 import sys, requests


### PR DESCRIPTION
## Changelog
- Create new Consul dashboard ([see it here](https://app2.outlyer.com/outlyer/dashboards/consul))
- Update plugin to scrape metrics from HTTP API and `/metrics` endpoint
- Create default alerts
- Create integration docs

## TLS Test
- [ ] Run [this consul plugin](https://app2.outlyer.com/outlyer/checks/consul) with no environment variables configured at all. It will hit the regular HTTP API without TLS and should work fine.
- [ ] Add the environment variables **protocol** with value `https` and **port** with value `8080` to hit the configured HTTPS TLS secured API for this Consul cluster and try it again. You should see a TLS error as the certificates paths are not being passed as environment variables to the plugin.
- [ ] Keep the variables in the last step and add the certificate paths as environment variables as shown below and run the plugin again. Now it should work.
- **client_cert_file** `/etc/consul.d/ssl/consul.cert`
- **private_key_file** `/etc/consul.d/ssl/consul.key`
- **ca_bundle_file** `/etc/consul.d/ssl/ca.cert`