### PR TITLE
[fix-zk-dashboard] Adds scope and fixes ZooKeeper dashboard

### DIFF
--- a/zookeeper/README.md
+++ b/zookeeper/README.md
@@ -29,7 +29,7 @@ Once enabled you will get a default ZooKeeper dashboard and alert rules to help 
 |zk_followers                 |Gauge  |      |           |Number of followers.                                                                                                     |
 |zk_synced_followers          |Gauge  |      |           |Current number of synced followers.                                                                                      |
 |zk_pending_syncs             |Gauge  |      |           |Current number of pending syncs.                                                                                         |
-
+|zk_disk_used_pct             |Gauge  |device|fraction   |The percentage of disk used per partition.                                                                               |
 
 == Installation ==
 
@@ -48,6 +48,7 @@ The ZooKeeper plugin can be customized via environment variables.
 
 |Version|Release Date|Description                                             |
 |-------|------------|--------------------------------------------------------|
+|1.0.3  |04-Oct-2018 |Adds dashboard scope and fixes widgets.                 |
 |1.0.2  |28-Sep-2018 |Fixes ZooKeeper dashboard logo URL and updates docs.    |
 |1.0.1  |28-Sep-2018 |Uses ip environment variable instead of host.           |
 |1.0    |25-May-2018 |Initial version of our ZooKeeper monitoring integration.|

--- a/zookeeper/dashboards/zookeeper.yaml
+++ b/zookeeper/dashboards/zookeeper.yaml
@@ -8,7 +8,9 @@ labels:
 - key: zookeeper
   value: ""
 name: zookeeper
-scopes: []
+scopes:
+- defaultValue: None
+  labelKey: host
 theme: light
 title: ZooKeeper
 widgets:
@@ -100,10 +102,10 @@ widgets:
         linkType: dashboard
         path: ""
       queries:
-      - query: name,zk_open_file_descriptor_count,:eq,:max,(,host,),:by
+      - query: name,zk_open_file_descriptor_count,:eq,:max,(,host,name,),:by
         scoped: true
         visible: true
-      - query: name,zk_max_file_descriptor_count,:eq,:max,(,host,),:by
+      - query: name,zk_max_file_descriptor_count,:eq,:max,(,host,name,),:by
         scoped: true
         visible: true
       seriesStyle:
@@ -158,7 +160,7 @@ widgets:
       axes:
         xAxis:
           mode: Time
-          showGridLines: true
+          showGridLines: false
         yAxis:
           min: 0
           showGridLines: false
@@ -172,7 +174,7 @@ widgets:
         linkType: dashboard
         path: ""
       queries:
-      - query: name,sys.disk.used_pct,:eq,role,zookeeper,:eq,:and,:max,(,host,),:by
+      - query: name,zk_disk_used_pct,:eq,:max,(,host,device,),:by
         scoped: true
         visible: true
       seriesStyle:
@@ -200,16 +202,16 @@ widgets:
           title: ""
           unit: ""
           unitPosition: After
-      chartType: Bar
+      chartType: Line
       description: ""
       externalLink:
         linkType: dashboard
         path: ""
       queries:
-      - query: name,zk_packets_received,:eq,:max
+      - query: name,zk_packets_received,:eq,:max,(,host,name,),:by
         scoped: true
         visible: true
-      - query: name,zk_packets_sent,:eq,:max
+      - query: name,zk_packets_sent,:eq,:max,(,host,name,),:by
         scoped: true
         visible: true
       seriesStyle:
@@ -368,7 +370,7 @@ widgets:
         path: ""
       icon: integration--java
       query:
-        query: name,zk_znode_count,:eq,:max
+        query: name,zk_znode_count,:eq,:sum,:cf-sum
         scoped: true
         visible: true
       rounding: None
@@ -392,7 +394,7 @@ widgets:
         path: ""
       icon: integration--java
       query:
-        query: name,zk_watch_count,:eq,:max
+        query: name,zk_watch_count,:eq,:sum,:cf-sum
         scoped: true
         visible: true
       rounding: None
@@ -408,25 +410,25 @@ widgets:
   - col: 2
     height: 2
     options:
-      color: '#588fd8'
+      color: '#4dccc5'
       description: ""
       displayMax: 0
       displayMin: 0
-      displayTrend: None
+      displayTrend: Gauge
       externalLink:
         linkType: dashboard
         path: ""
-      icon: insert_emoticon
+      icon: thumb_up
       query:
-        query: name,host.status,:eq,role,zookeeper,:eq,:and,:count,:cf-max
-        scoped: true
+        query: name,zk_znode_count,:eq,:count,:cf-max
+        scoped: false
         visible: true
       rounding: None
       statistic: LastValue
       thresholds:
       - status: Error
         threshold: 0
-      title: Nodes
+      title: Cluster Nodes
       unit: ""
       unitPosition: After
     row: 0
@@ -442,7 +444,7 @@ widgets:
         path: ""
       icon: integration--java
       query:
-        query: name,zk_pending_syncs,:eq,:max
+        query: name,zk_pending_syncs,:eq,:max,:cf-max
         scoped: true
         visible: true
       rounding: None

--- a/zookeeper/package.yaml
+++ b/zookeeper/package.yaml
@@ -3,7 +3,7 @@ title: Zookeeper
 description: Outlyer Monitoring Integration for Zookeeper, the centralized service for maintaining cluster configuration information
 icon:
   url: zookeeper.svg
-version: 1.0.2
+version: 1.0.3
 author: Outlyer
 author-uri: https://www.outlyer.com
 license: MIT

--- a/zookeeper/plugins/zookeeper.py
+++ b/zookeeper/plugins/zookeeper.py
@@ -71,7 +71,7 @@ class ZookeeperPlugin(Plugin):
                 self.counter(key, {'zookeeper': key}).set(int(value))
             elif key in GAUGE_METRICS:
                 self.gauge(key, {'zookeeper': key}).set(int(value))
-        
+
         instance_type = self.get('instance.type')
         if instance_type == "container":
             zookeeper_container_name = self.get('instance.alias', None)
@@ -91,7 +91,7 @@ class ZookeeperPlugin(Plugin):
                     used_pct = line[4].replace('%', '')
                     self.gauge('zk_disk_used_pct', {'device': device}).set(float(used_pct))
         else:
-            for partition in psutil.disk_partitions(all=False):
+            for partition in psutil.disk_partitions(all=True):
                 labels = {'device': partition.device}
                 self.gauge('zk_disk_used_pct', labels).set(psutil.disk_usage(partition.mountpoint).percent)
 


### PR DESCRIPTION
## Changelog
- Adds scope to dashboard
- Collects metric `zk_disk_used_pct`, which works on both containers and regular hosts
- Updates docs with new metric
- Updates docs and package version

See the [new dashboard running on regular hosts](https://app2.outlyer.com/outlyer/dashboards/zookeeper-1) (no containers).
See the [new dashboard running on containers](https://app2.outlyer.com/demo/dashboards/zookeeper-1) (containers managed by K8s on demo environment).

Note: the dashboard logo widget is showing a scroll bar (for this and others dashboards as well), Nuno is already looking into it.