### PR TITLE
Update http_check.py

### DIFF
--- a/http/plugins/http_check.py
+++ b/http/plugins/http_check.py
@@ -9,7 +9,7 @@ class HttpRequestPlugin(Plugin):
 
     def collect(self, _) -> Status:
 
-        name = self.get('name')
+        name = self.get('site')
         url = self.get('url')
         if not url or not name:
             self.logger.error('HTTP plugin is not configured')


### PR DESCRIPTION
Name is a reserved tag so if you set the name env variable in a check it always get overwritten by the name label of the host you are running this check against.