### PR TITLE
Kafka consumer lag monitoring

### DIFF
--- a/kafka/checks/kafka-broker.yaml
+++ b/kafka/checks/kafka-broker.yaml
@@ -1,7 +1,7 @@
 command: kafka.py
 dashboards:
 - kafka-cluster-overview
-description: Monitors Kafka broker metrics via JMX.
+description: Monitors Kafka broker metrics.
 disabled: false
 env: []
 handler: Native
@@ -13,3 +13,7 @@ plugins:
 selectors: {{.selectors_kafka_broker}}
 timeout: 30
 title: 'Kafka: Brokers'
+- kafka_consumer_lag.py
+selectors: {{.selectors_kafka_broker}}
+timeout: 30
+title: 'Kafka: Consumers'

--- a/kafka/dashboards/kafka-cluster-overview.yaml
+++ b/kafka/dashboards/kafka-cluster-overview.yaml
@@ -48,7 +48,7 @@ widgets:
       title: Clean Vs. Unclean Leader Election Rate
     row: 0
     width: 6
-  - col: 6
+  - col: 4
     height: 2
     options:
       axes:
@@ -80,9 +80,9 @@ widgets:
         status: Error
         threshold: 0
       title: Network Requests Per Sec
-    row: 6
-    width: 6
-  - col: 6
+    row: 8
+    width: 5
+  - col: 9
     height: 2
     options:
       axes:
@@ -115,8 +115,8 @@ widgets:
         threshold: 0
       title: Messages In Per Sec (Per Broker)
     row: 4
-    width: 6
-  - col: 12
+    width: 9
+  - col: 9
     height: 2
     options:
       axes:
@@ -150,9 +150,9 @@ widgets:
         status: Error
         threshold: 0
       title: Bytes In / Bytes Out Per Sec
-    row: 4
-    width: 6
-  - col: 12
+    row: 6
+    width: 9
+  - col: 9
     height: 2
     options:
       axes:
@@ -184,9 +184,9 @@ widgets:
         status: Error
         threshold: 0
       title: Total Request Time
-    row: 6
-    width: 6
-  - col: 12
+    row: 8
+    width: 5
+  - col: 6
     height: 2
     options:
       axes:
@@ -218,7 +218,7 @@ widgets:
         status: Error
         threshold: 1
       title: ISR Delta Rate of Change
-    row: 8
+    row: 10
     width: 6
   - col: 12
     height: 2
@@ -252,7 +252,7 @@ widgets:
         status: Error
         threshold: 0
       title: Garbage Collection Time Rate
-    row: 13
+    row: 15
     width: 6
   - col: 0
     height: 2
@@ -289,9 +289,9 @@ widgets:
         status: Error
         threshold: 0
       title: Heap Memory Committed Vs. Used
-    row: 13
+    row: 15
     width: 6
-  - col: 0
+  - col: 12
     height: 2
     options:
       axes:
@@ -323,9 +323,9 @@ widgets:
         status: Error
         threshold: 0
       title: ISR Shrinks Per Sec
-    row: 8
+    row: 10
     width: 6
-  - col: 6
+  - col: 0
     height: 2
     options:
       axes:
@@ -357,7 +357,7 @@ widgets:
         status: Error
         threshold: 0
       title: ISR Expands Per Sec
-    row: 8
+    row: 10
     width: 6
   - col: 9
     height: 2
@@ -393,7 +393,7 @@ widgets:
       title: Partition Leader Per Broker
     row: 2
     width: 3
-  - col: 0
+  - col: 14
     height: 2
     options:
       axes:
@@ -425,8 +425,8 @@ widgets:
         status: Error
         threshold: 0
       title: MaxLag Per Broker
-    row: 6
-    width: 6
+    row: 8
+    width: 4
   - col: 12
     height: 2
     options:
@@ -462,7 +462,7 @@ widgets:
         status: Error
         threshold: 0
       title: Classes Loaded vs Unloaded
-    row: 11
+    row: 13
     width: 6
   - col: 0
     height: 2
@@ -499,8 +499,8 @@ widgets:
         status: Error
         threshold: 0
       title: Opened vs Total File Descriptors
-    row: 4
-    width: 6
+    row: 8
+    width: 4
   - col: 6
     height: 2
     options:
@@ -533,8 +533,42 @@ widgets:
         status: Error
         threshold: 0
       title: Garbage Collection Count Rate
-    row: 13
+    row: 15
     width: 6
+  - col: 0
+    height: 4
+    options:
+      axes:
+        xAxis:
+          mode: Time
+          showGridLines: true
+        yAxis:
+          min: 0
+          showGridLines: true
+          title: ""
+          unit: none
+          unitPosition: After
+      chartType: Line
+      description: ""
+      externalLink:
+        linkType: dashboard
+        path: ""
+      queries:
+      - query: name,kafka_consumer_lag,:eq,:max,:cf-max,(,topic,consumer_group,topic_partition,),:by
+        scoped: true
+        visible: true
+      seriesStyle:
+        color: '#588fd8'
+        palette: MultiColor
+      summarization: Avg
+      thresholds:
+      - display: None
+        lineStyle: Solid
+        status: Error
+        threshold: 0
+      title: Consumer Lag
+    row: 4
+    width: 9
   imageWidgets:
   - col: 0
     height: 2
@@ -542,7 +576,7 @@ widgets:
       color: '#dd3e26'
       icon: integration--java
       sizing: stretched
-    row: 11
+    row: 13
     width: 3
   markdownWidgets:
   - col: 0
@@ -560,7 +594,7 @@ widgets:
       content: |
         <h1><strong>Java Virtual Machine</strong></h1>
       markdown: '# **Java Virtual Machine**'
-    row: 10
+    row: 12
     width: 18
   numberWidgets:
   - col: 3
@@ -783,7 +817,7 @@ widgets:
       title: Live Threads
       unit: ""
       unitPosition: After
-    row: 11
+    row: 13
     width: 3
   - col: 6
     height: 2
@@ -809,7 +843,7 @@ widgets:
       title: Peak Threads
       unit: ""
       unitPosition: After
-    row: 11
+    row: 13
     width: 3
   - col: 9
     height: 2
@@ -835,5 +869,5 @@ widgets:
       title: Daemon Threads
       unit: ""
       unitPosition: After
-    row: 11
+    row: 13
     width: 3

--- a/kafka/package.yaml
+++ b/kafka/package.yaml
@@ -3,7 +3,7 @@ title: Kafka
 description: Outlyer Monitoring Integration for Kafka, the distributed streaming and message queue platform
 icon:
   url: https://raw.githubusercontent.com/outlyerapp/integrations/master/kafka/resources/kafka.svg?sanitize=true
-version: 1.0.1
+version: 1.1.0
 author: 
   name: Outlyer
   url: https://www.outlyer.com

--- a/kafka/plugins/kafka-consumer-lag.py
+++ b/kafka/plugins/kafka-consumer-lag.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import logging
+import re
+import sys
+
+from outlyer_plugin import Status, Plugin
+
+import pykafka
+from pykafka.cli import kafka_tools
+from pykafka.utils.compat import iteritems
+
+class MemberLag(object):
+    def __init__(self, topic, group, member, partition, latest_offset, current_offset):
+        self.topic = topic.decode('UTF-8')
+        self.group = group.decode('UTF-8')
+        self.member = member.decode('UTF-8')
+        self.partition = str(partition)
+        self.latest_offset = latest_offset
+        self.current_offset = current_offset
+
+    def lag(self):
+        return self.latest_offset - self.current_offset
+
+class KafkaConsumerLagPlugin(Plugin):
+    def collect(self, _):
+        try:
+            # Disable verbose logging for Kafka client lib 
+            logger = logging.getLogger("pykafka")
+            logger.setLevel(logging.ERROR)
+
+            host = self.get('ip', 'localhost')
+            port = self.get('port', 9092)
+            consumer_group_regex = re.compile(self.get('consumer_group_regex', '.*'))
+            consumer_group_names = self.get('consumer_groups', '')
+
+            server = f'{host}:{port}'
+            client = pykafka.KafkaClient(hosts=server)
+
+            consumer_groups = set(map(lambda g: g.encode('UTF-8'), filter(lambda g: len(g) > 0, consumer_group_names.split(','))))
+
+            brokers = client.brokers
+
+            group_topics = {}
+            member_assignment = {}
+            for _, broker in iteritems(brokers):
+                broker_groups = broker.list_groups().groups.keys()
+                if consumer_groups:
+                    groups = list(filter(lambda g: g in consumer_groups, broker_groups))
+                else:
+                    groups = list(filter(lambda g: consumer_group_regex.match(g.decode('UTF-8')), broker_groups))
+
+                groups_metadata = broker.describe_groups(group_ids=groups).groups
+                for group_id, describe_group_response in iteritems(groups_metadata):
+                    members = describe_group_response.members
+                    topics = set([])
+                    for member_id, member in iteritems(members):
+                        for topic, assignments in member.member_assignment.partition_assignment:
+                            topics.add(topic)
+                            for assignment in assignments:
+                                member_assignment[(topic, group_id, assignment)] = member_id
+                    group_topics[group_id] = topics
+
+            lags = []
+            for group_id, topics in iteritems(group_topics):
+                for topic_name in topics:
+                    topic = client.topics[topic_name]
+                    lag = kafka_tools.fetch_consumer_lag(client, topic, group_id)
+                    for partition, offsets in iteritems(lag):
+                        member = member_assignment[(topic_name, group_id, partition)]
+                        lags.append(MemberLag(topic_name, group_id, member, partition, offsets[0], offsets[1]))
+
+            for lag in lags:
+                labels = {
+                    'topic': lag.topic,
+                    'consumer_group': lag.group,
+                    'consumer_client_id': lag.member,
+                    'topic_partition': lag.partition
+                }
+                self.gauge('kafka_consumer_lag', labels).set(lag.lag())
+
+            return Status.OK
+        except Exception:
+            self.logger.error('Unable to scrape metrics from Kafka')
+            return Status.CRITICAL
+
+
+if __name__ == '__main__':
+    sys.exit(KafkaConsumerLagPlugin().run())


### PR DESCRIPTION
Add new plugin for monitoring consumer lag.

I've added instructions on how to install the python dependency in the agent manually, but I can remove it if we think it might consuse people and just leave a note about agent version.

I also modified the broker dashboard so it looks like this now, with a nice big graph for consumer lag:

![dash](https://i.imgur.com/CPzw5Qm.jpg)